### PR TITLE
Review azarashin 2nd

### DIFF
--- a/pset4/filter/less/helpers.c
+++ b/pset4/filter/less/helpers.c
@@ -10,6 +10,12 @@ void grayscale(int height, int width, RGBTRIPLE image[height][width])
     {
         for (int j = 0; j < width; j++)
         {
+            // [notice]
+            // 汎整数拡張 という仕組みで、BYTE 型同士の足し算をした結果が一時的にint 型に拡張されています。
+            // なので、内部的には
+            // (BYTE)255 + (BYTE)255 -> (int)(BYTE)255 + (int)(BYTE)255 -> (int)510
+            // と評価されます。
+            // 今回は関係していませんが、ビット演算や符号有り・無しを区別しているケースではビット長や型に注意。
             BYTE average = round((image[i][j].rgbtRed + image[i][j].rgbtGreen + image[i][j].rgbtBlue) / 3.0);
             image[i][j].rgbtRed = average;
             image[i][j].rgbtGreen = average;
@@ -55,6 +61,10 @@ void sepia(int height, int width, RGBTRIPLE image[height][width])
 // Reflect image horizontally
 void reflect(int height, int width, RGBTRIPLE image[height][width])
 {
+    // [notice]
+    // ここはcopy 配列を使わずに記述できるでしょう。
+    // また、仮にcopy 配列を使う場合でも、要素を一つ一つ代入するよりは、
+    // memcpy などの関数を使う方が高速です。    
     RGBTRIPLE copy[height][width];
     for (int i = 0; i < height; i++)
     {
@@ -72,6 +82,16 @@ void reflect(int height, int width, RGBTRIPLE image[height][width])
 // Blur image
 void blur(int height, int width, RGBTRIPLE image[height][width])
 {
+    // [notice]
+    // ここはメモリを確保して変換前・変換後のバッファが両方存在する必要があるので、
+    // copy 領域を確保するやり方でＯＫです。
+    // 高速なmemcpy を使いましょう。
+    // (おまけ)
+    // 画像処理の場合、4byte alignment に注意。
+    // OpenCV などの画像ライブラリでは、画像バッファの横方向のラインを確保する際に
+    // バッファのサイズが4の倍数になるように、バッファの後ろにダミーデータが詰められることもあります。
+    // (画像ライブラリでalignment の情報を取得出来たり、予め仕様で決まっていたりします。)
+    // ダミーデータが入っていると、memcpy の時のバッファサイズ計算が変わってくるので注意。
     RGBTRIPLE copy[height][width];
     for (int i = 0; i < height; i++)
     {

--- a/pset4/filter/less/helpers.c
+++ b/pset4/filter/less/helpers.c
@@ -10,7 +10,7 @@ void grayscale(int height, int width, RGBTRIPLE image[height][width])
     {
         for (int j = 0; j < width; j++)
         {
-            // [notice]
+            // [note]
             // 汎整数拡張 という仕組みで、BYTE 型同士の足し算をした結果が一時的にint 型に拡張されています。
             // なので、内部的には
             // (BYTE)255 + (BYTE)255 -> (int)(BYTE)255 + (int)(BYTE)255 -> (int)510

--- a/pset4/filter/more/helpers.c
+++ b/pset4/filter/more/helpers.c
@@ -1,5 +1,6 @@
 #include <math.h>
 #include <stdlib.h>
+#include <memory.h>
 
 #include "helpers.h"
 
@@ -21,20 +22,13 @@ void grayscale(int height, int width, RGBTRIPLE image[height][width])
 // Reflect image horizontally
 void reflect(int height, int width, RGBTRIPLE image[height][width])
 {
-    // [notice]
-    // ここはcopy 配列を使わずに記述できるでしょう。
-    // また、仮にcopy 配列を使う場合でも、要素を一つ一つ代入するよりは、
-    // memcpy などの関数を使う方が高速です。    
-    RGBTRIPLE copy[height][width];
     for (int i = 0; i < height; i++)
     {
-        for (int j = 0; j < width; j++)
+        for (int j = 0; j < width / 2; j++)
         {
-            copy[i][j] = image[i][j];
-        }
-        for (int j = 0; j < width; j++)
-        {
-            image[i][j] = copy[i][width - 1 - j];
+            RGBTRIPLE pxa = image[i][j];
+            image[i][j] = image[i][width - 1 - j];
+            image[i][width - 1 - j] = pxa;
         }
     }
 }
@@ -42,18 +36,8 @@ void reflect(int height, int width, RGBTRIPLE image[height][width])
 // Blur image
 void blur(int height, int width, RGBTRIPLE image[height][width])
 {
-    // [notice]
-    // ここはメモリを確保して変換前・変換後のバッファが両方存在する必要があるので、
-    // copy 領域を確保するやり方でＯＫです。
-    // 高速なmemcpy を使いましょう。
     RGBTRIPLE copy[height][width];
-    for (int i = 0; i < height; i++)
-    {
-        for (int j = 0; j < width; j++)
-        {
-            copy[i][j] = image[i][j];
-        }
-    }
+    memcpy(copy, image, sizeof(RGBTRIPLE) * width * height);
 
     for (int i = 0; i < height; i++)
     {
@@ -99,57 +83,13 @@ void edges(int height, int width, RGBTRIPLE image[height][width])
     int gx[3][3] = {{-1, 0, 1}, {-2, 0, 2}, {-1, 0, 1}};
     int gy[3][3] = {{-1, -2, -1}, {0, 0, 0}, {1, 2, 1}};
 
-    // [notice]
-    // ここもmemcpy を使いましょう。
-    for (int i = 0; i < height; i++)
-    {
-        for (int j = 0; j < width; j++)
-        {
-            result_gx[i][j].red = 0;
-            result_gx[i][j].green = 0;
-            result_gx[i][j].blue = 0;
-            result_gy[i][j].red = 0;
-            result_gy[i][j].green = 0;
-            result_gy[i][j].blue = 0;
-        }
-    }
+    memset(result_gx, 0, sizeof(result_gx)); 
+    memset(result_gy, 0, sizeof(result_gy)); 
 
     for (int i = 0; i < height; i++)
     {
         for (int j = 0; j < width; j++)
         {
-            // [note]
-            // ここは敢えて修正不要ですが(速度〇、品質△、実行ファイルサイズ〇)、
-            // 選択肢がいくつかあります（ケースバイケース。半分雑学。）
-            // 
-            // opt 1. for (int k = i - 1... の部分を関数化してコードの見通しをよくする(速度△、品質〇、実行ファイルサイズ〇)
-            // 
-            // ネストが深いのはコード品質的にはよろしくないので、関数化すると見通しが良くなります。
-            // 一方、関数呼び出し自体にオーバーヘッドがありますので、実行速度は下がる傾向にあります。
-            // 但し、コンパイラの最適化によってこのオーバーヘッドはある程度の解消が期待できるので、
-            // 関数化はコード品質向上のための一つの選択肢です。
-            //
-            // 
-            // opt 2. k とl の組み合わせは3x3 の9通りなので、9通りをループを使わずに記述する(速度◎、品質×、実行ファイルサイズ×)
-            // 
-            // ループ処理自体にもオーバーヘッドがあります。分岐処理をすることで命令パイプラインが乱れ、実行速度の低下を招きます。
-            // (命令パイプラインの説明は端折りますが、ざっくり言うと、連続する命令をプロセッサレベルでプチ並列化して高速化する技術です。)
-            // ループ回数が予め分かっている場合、中身を展開すると命令パイプラインがうまく働いて高速化が期待できます。
-            // 。。。ただ、賢いコンパイラであればこの辺はうまくコンパイル時に最適化してくれたりもするので、
-            // この対策を実施することはほとんどないでしょうね。。。
-            // 出番があるとすれば、性能の低いコンパイラを使っている場合に、コード品質・ファイルサイズを犠牲にしてでも高速化したい時でしょうか。。。
-            // 極端な高速化が求められる場合なので、画像処理などの一部の用途限定で、
-            // opt 1 で品質をある程度担保した後のチューニングフェーズ
-            // でやる可能性があるくらいでしょうか…（最初からコード品質を犠牲にすると沼にハマるので注意。）
-            //
-            // opt 3. (C++ 限定)インライン関数を使う(速度〇、品質〇、実行ファイルサイズ△)
-            //
-            // opt 1 を実施する際に、インライン関数を使うと関数呼び出しのオーバーヘッドを避けながら
-            // コードの見通しを改善することができます。
-            // 但し、C++ 限定であることと、呼び出し箇所が複数の場合に実行ファイルのサイズが大きくなることが欠点です。
-            // (Arduinoのようなメモリの少ない環境では無視できなくなる。今回は呼び出し箇所が1か所だけなので影響軽微。)
-            //
-            // オススメは、現状維持のままか、opt 1 とコンパイルの最適化の併用で、コードの品質向上を図るか、でしょうかね。
             for (int k = i - 1, m = 0; k <= i + 1; k++, m++)
             {
                 for (int l = j - 1, n = 0; l <= j + 1; l++, n++)
@@ -163,17 +103,6 @@ void edges(int height, int width, RGBTRIPLE image[height][width])
                         result_gy[i][j].green += gy[m][n] * image[k][l].rgbtGreen;
                         result_gy[i][j].blue += gy[m][n] * image[k][l].rgbtBlue;
                     }
-                    else
-                    {
-                        // [notice]
-                        // ここのコードは不要では？(0を加算しているだけで、実行後に変化がないため。)
-                        result_gx[i][j].red += 0;
-                        result_gx[i][j].green += 0;
-                        result_gx[i][j].blue += 0;
-                        result_gy[i][j].red += 0;
-                        result_gy[i][j].green += 0;
-                        result_gy[i][j].blue += 0;
-                    }
                 }
             }
         }
@@ -183,11 +112,6 @@ void edges(int height, int width, RGBTRIPLE image[height][width])
     {
         for (int j = 0; j < width; j++)
         {
-            // [note]
-            // このコードで維持、ですかね。
-            // rgb それぞれ同じような処理なので関数化する方が見通しが良いですが、
-            // 関数呼び出しのオーバーヘッドで処理速度低下を招くかもしれないので、
-            // べた書きでもＯＫかと思います。
             int edge_red = round(sqrt((result_gx[i][j].red * result_gx[i][j].red) + (result_gy[i][j].red * result_gy[i][j].red)));
             if (edge_red > 255)
             {

--- a/pset4/filter/more/helpers.c
+++ b/pset4/filter/more/helpers.c
@@ -21,6 +21,10 @@ void grayscale(int height, int width, RGBTRIPLE image[height][width])
 // Reflect image horizontally
 void reflect(int height, int width, RGBTRIPLE image[height][width])
 {
+    // [notice]
+    // ここはcopy 配列を使わずに記述できるでしょう。
+    // また、仮にcopy 配列を使う場合でも、要素を一つ一つ代入するよりは、
+    // memcpy などの関数を使う方が高速です。    
     RGBTRIPLE copy[height][width];
     for (int i = 0; i < height; i++)
     {
@@ -38,6 +42,10 @@ void reflect(int height, int width, RGBTRIPLE image[height][width])
 // Blur image
 void blur(int height, int width, RGBTRIPLE image[height][width])
 {
+    // [notice]
+    // ここはメモリを確保して変換前・変換後のバッファが両方存在する必要があるので、
+    // copy 領域を確保するやり方でＯＫです。
+    // 高速なmemcpy を使いましょう。
     RGBTRIPLE copy[height][width];
     for (int i = 0; i < height; i++)
     {
@@ -91,6 +99,8 @@ void edges(int height, int width, RGBTRIPLE image[height][width])
     int gx[3][3] = {{-1, 0, 1}, {-2, 0, 2}, {-1, 0, 1}};
     int gy[3][3] = {{-1, -2, -1}, {0, 0, 0}, {1, 2, 1}};
 
+    // [notice]
+    // ここもmemcpy を使いましょう。
     for (int i = 0; i < height; i++)
     {
         for (int j = 0; j < width; j++)
@@ -108,6 +118,38 @@ void edges(int height, int width, RGBTRIPLE image[height][width])
     {
         for (int j = 0; j < width; j++)
         {
+            // [note]
+            // ここは敢えて修正不要ですが(速度〇、品質△、実行ファイルサイズ〇)、
+            // 選択肢がいくつかあります（ケースバイケース。半分雑学。）
+            // 
+            // opt 1. for (int k = i - 1... の部分を関数化してコードの見通しをよくする(速度△、品質〇、実行ファイルサイズ〇)
+            // 
+            // ネストが深いのはコード品質的にはよろしくないので、関数化すると見通しが良くなります。
+            // 一方、関数呼び出し自体にオーバーヘッドがありますので、実行速度は下がる傾向にあります。
+            // 但し、コンパイラの最適化によってこのオーバーヘッドはある程度の解消が期待できるので、
+            // 関数化はコード品質向上のための一つの選択肢です。
+            //
+            // 
+            // opt 2. k とl の組み合わせは3x3 の9通りなので、9通りをループを使わずに記述する(速度◎、品質×、実行ファイルサイズ×)
+            // 
+            // ループ処理自体にもオーバーヘッドがあります。分岐処理をすることで命令パイプラインが乱れ、実行速度の低下を招きます。
+            // (命令パイプラインの説明は端折りますが、ざっくり言うと、連続する命令をプロセッサレベルでプチ並列化して高速化する技術です。)
+            // ループ回数が予め分かっている場合、中身を展開すると命令パイプラインがうまく働いて高速化が期待できます。
+            // 。。。ただ、賢いコンパイラであればこの辺はうまくコンパイル時に最適化してくれたりもするので、
+            // この対策を実施することはほとんどないでしょうね。。。
+            // 出番があるとすれば、性能の低いコンパイラを使っている場合に、コード品質・ファイルサイズを犠牲にしてでも高速化したい時でしょうか。。。
+            // 極端な高速化が求められる場合なので、画像処理などの一部の用途限定で、
+            // opt 1 で品質をある程度担保した後のチューニングフェーズ
+            // でやる可能性があるくらいでしょうか…（最初からコード品質を犠牲にすると沼にハマるので注意。）
+            //
+            // opt 3. (C++ 限定)インライン関数を使う(速度〇、品質〇、実行ファイルサイズ△)
+            //
+            // opt 1 を実施する際に、インライン関数を使うと関数呼び出しのオーバーヘッドを避けながら
+            // コードの見通しを改善することができます。
+            // 但し、C++ 限定であることと、呼び出し箇所が複数の場合に実行ファイルのサイズが大きくなることが欠点です。
+            // (Arduinoのようなメモリの少ない環境では無視できなくなる。今回は呼び出し箇所が1か所だけなので影響軽微。)
+            //
+            // オススメは、現状維持のままか、opt 1 とコンパイルの最適化の併用で、コードの品質向上を図るか、でしょうかね。
             for (int k = i - 1, m = 0; k <= i + 1; k++, m++)
             {
                 for (int l = j - 1, n = 0; l <= j + 1; l++, n++)
@@ -123,6 +165,8 @@ void edges(int height, int width, RGBTRIPLE image[height][width])
                     }
                     else
                     {
+                        // [notice]
+                        // ここのコードは不要では？(0を加算しているだけで、実行後に変化がないため。)
                         result_gx[i][j].red += 0;
                         result_gx[i][j].green += 0;
                         result_gx[i][j].blue += 0;
@@ -139,6 +183,11 @@ void edges(int height, int width, RGBTRIPLE image[height][width])
     {
         for (int j = 0; j < width; j++)
         {
+            // [note]
+            // このコードで維持、ですかね。
+            // rgb それぞれ同じような処理なので関数化する方が見通しが良いですが、
+            // 関数呼び出しのオーバーヘッドで処理速度低下を招くかもしれないので、
+            // べた書きでもＯＫかと思います。
             int edge_red = round(sqrt((result_gx[i][j].red * result_gx[i][j].red) + (result_gy[i][j].red * result_gy[i][j].red)));
             if (edge_red > 255)
             {


### PR DESCRIPTION
pset4 のレビューをしました。
全体的にmemcpy とmemset を使うことでコード量をかなり短くできると思います。
（一か所コメントでmemset をmemcpy と書き間違えたところありますごめんなさい）

コメントは、修正が好ましい[notice] よりも、修正不要で参考までに見ておいてほしい[note]の
方が今回は多いです。
